### PR TITLE
Add setting trigger device in API functions

### DIFF
--- a/+adi/ADIS16375.m
+++ b/+adi/ADIS16375.m
@@ -62,6 +62,12 @@ classdef ADIS16375 < adi.IMUBase
             icon = sprintf('ADIS16375');
         end
         
+        function setupInit(obj)
+            trig = getDev(obj, 'adis16375-dev0');
+            iio_device_set_trigger(obj, obj.iioDev, trig);
+            setupInit@adi.IMUBase(obj); % call superclass setupInit
+        end
+
     end
         
     %% External Dependency Methods

--- a/+adi/ADIS16480.m
+++ b/+adi/ADIS16480.m
@@ -63,6 +63,12 @@ classdef ADIS16480 < adi.IMUBase
             icon = sprintf('ADIS16480');
         end
         
+        function setupInit(obj)
+            trig = getDev(obj, 'adis16480-dev0');
+            iio_device_set_trigger(obj, obj.iioDev, trig);
+            setupInit@adi.IMUBase(obj); % call superclass setupInit
+        end
+        
     end
         
     %% External Dependency Methods


### PR DESCRIPTION
Signed-off-by: Julia Pineda <Julia.Pineda@analog.com>

ADIS16375 and ADIS16480 are known to require the device trigger to be set.