### PR TITLE
adis16480 accel and gyro reads only

### DIFF
--- a/+adi/ADIS16480.m
+++ b/+adi/ADIS16480.m
@@ -38,12 +38,6 @@ classdef ADIS16480 < adi.IMUBase
         end
     end   
     
-%     methods (Access=protected)%REMOVED WHILE stepImpl USES varargout
-%         function numOut = getNumOutputsImpl(~)
-%             numOut = 3;
-%         end       
-%     end
-    
     %% Sensor specific APIs
     methods
         function [varargout] = read(obj)

--- a/+adi/ADIS16480.m
+++ b/+adi/ADIS16480.m
@@ -56,7 +56,14 @@ classdef ADIS16480 < adi.IMUBase
         
         function [accelReadings, gyroReadings, magReadings, valid] = stepImpl(obj)
             [dataR, valid] = stepImpl@adi.common.Rx(obj);
-            [accelReadings, gyroReadings, magReadings] = stepAccelGyroMag(obj, dataR);
+            switch length(obj.EnabledChannels)
+                case 6
+                    [accelReadings, gyroReadings] = stepAccelGyro(obj, dataR);
+                    magReadings = null(obj.SamplesPerRead,3);
+                case 9
+                    [accelReadings, gyroReadings, magReadings] = stepAccelGyroMag(obj, dataR);
+            end
+            
         end
         
         function icon = getIconImpl(~)

--- a/+adi/IMUBase.m
+++ b/+adi/IMUBase.m
@@ -128,8 +128,8 @@ classdef IMUBase < matlab.system.mixin.CustomIcon & adi.common.Rx ...
         end
                
         function scales = setScales(obj)
-            scales = zeros(1,length(obj.channel_names));
-            for c = 1:length(obj.channel_names)
+            scales = zeros(1,length(obj.EnabledChannels));
+            for c = 1:length(obj.EnabledChannels)
                 scales(c) = obj.getAttributeDouble(obj.channel_names{c},'scale',false);
             end
         end

--- a/sensor_examples/adis16460_motion.m
+++ b/sensor_examples/adis16460_motion.m
@@ -14,22 +14,24 @@ ifilt = imufilter('SampleRate', fs);
 % Scopes
 N = 64;
 viewer = HelperOrientationViewer;
-ts = dsp.TimeScope;
-ts.SampleRate = fs;
-ts.TimeSpanOverrunAction = 'Scroll';
-ts.TimeSpan = 1/fs*N;
-ts.NumInputPorts = 2;
-ts.ShowLegend = true;
-ts.ChannelNames = {'Acceleration X','Acceleration Y','Acceleration Z',...
-    'Angular Velocity X','Angular Velocity Y','Angular Velocity Z'};
-ts.ShowGrid = true;
-ts.LayoutDimensions = [2 ,1];
-ts.AxesScaling = 'Auto';
-ts_parts = clone(ts);
-ts_parts.LayoutDimensions = [1 ,1];
-ts_parts.NumInputPorts = 4;
-ts_parts.ChannelNames = {'W','X','Y','Z'};
-
+useScope = true;
+if useScope
+    ts = dsp.TimeScope;
+    ts.SampleRate = fs;
+    ts.TimeSpanOverrunAction = 'Scroll';
+    ts.TimeSpan = 1/fs*N;
+    ts.NumInputPorts = 2;
+    ts.ShowLegend = true;
+    ts.ChannelNames = {'Acceleration X','Acceleration Y','Acceleration Z',...
+        'Angular Velocity X','Angular Velocity Y','Angular Velocity Z'};
+    ts.ShowGrid = true;
+    ts.LayoutDimensions = [2 ,1];
+    ts.AxesScaling = 'Auto';
+    ts_parts = clone(ts);
+    ts_parts.LayoutDimensions = [1 ,1];
+    ts_parts.NumInputPorts = 4;
+    ts_parts.ChannelNames = {'W','X','Y','Z'};
+end
 %% Get info
 numSamples = IMU.SamplesPerFrame;
 t = 0:1/fs:(numSamples-1)/fs;
@@ -41,13 +43,17 @@ for k=1:N
         viewer(qimu);
         pause(0);
     end
-    ts(acc(ii,:), gyro(ii,:));
-    [w,x,y,z] = qimu.parts;
-    ts_parts(w,x,y,z);
+    if useScope
+        ts(acc(ii,:), gyro(ii,:));
+        [w,x,y,z] = qimu.parts;
+        ts_parts(w,x,y,z);
+    end
 end
 
 %% Cleanup
 release(ifilt);
 release(IMU);
 release(viewer);
-release(ts);
+if useScope
+    release(ts);
+end

--- a/sensor_examples/adis16480.m
+++ b/sensor_examples/adis16480.m
@@ -1,0 +1,45 @@
+clear all; %#ok<CLALL>
+
+%% ADIS16480 Example
+
+%% Setup
+% IMU
+IMU = adi.ADIS16480;
+IMU.SamplesPerRead = 32;
+IMU.uri = 'ip:analog';
+IMU.EnabledChannels = 1:6;
+% Filter
+fs = IMU.SampleRate;
+aFilter = imufilter('SampleRate',fs);
+
+%% Get info
+numSamples = IMU.SamplesPerFrame;
+t = 0:1/fs:(numSamples-1)/fs;
+
+[accelBody,gyroBody] = IMU();
+orientation = aFilter(accelBody,gyroBody);
+
+%% Cleanup
+release(aFilter);
+release(IMU);
+
+%% Plot
+figure;
+plot(t,eulerd(orientation,'ZYX','frame'))
+xlabel('Time (s)')
+ylabel('Rotation (degrees)')
+title('Orientation Estimation -- IMU Data, Default IMU Filter')
+legend('Z-axis','Y-axis','X-axis');
+grid on;
+figure;
+plot(t,accelBody);title('Acceleration');
+xlabel('Time (s)')
+ylabel('m/s^2');
+legend('X-axis','Y-axis','Z-axis');
+grid on;
+figure;
+plot(t,gyroBody);title('Angular Velocity');
+xlabel('Time (s)');
+ylabel('rad/s');
+legend('X-axis','Y-axis','Z-axis');
+grid on;

--- a/sensor_examples/adis16480_motion.m
+++ b/sensor_examples/adis16480_motion.m
@@ -15,22 +15,24 @@ ifilt = imufilter('SampleRate', fs);
 % Scopes
 N = 500;
 viewer = HelperOrientationViewer;
-% ts = dsp.TimeScope;
-% ts.SampleRate = fs;
-% ts.TimeSpanOverrunAction = 'Scroll';
-% ts.TimeSpan = 1/fs*N;
-% ts.NumInputPorts = 2;
-% ts.ShowLegend = true;
-% ts.ChannelNames = {'Acceleration X','Acceleration Y','Acceleration Z',...
-%     'Angular Velocity X','Angular Velocity Y','Angular Velocity Z'};
-% ts.ShowGrid = true;
-% ts.LayoutDimensions = [2 ,1];
-% ts.AxesScaling = 'Auto';
-% ts_parts = clone(ts);
-% ts_parts.LayoutDimensions = [1 ,1];
-% ts_parts.NumInputPorts = 4;
-% ts_parts.ChannelNames = {'W','X','Y','Z'};
-
+useScope = true;
+if useScope
+    ts = dsp.TimeScope;
+    ts.SampleRate = fs;
+    ts.TimeSpanOverrunAction = 'Scroll';
+    ts.TimeSpan = 1/fs*N;
+    ts.NumInputPorts = 2;
+    ts.ShowLegend = true;
+    ts.ChannelNames = {'Acceleration X','Acceleration Y','Acceleration Z',...
+        'Angular Velocity X','Angular Velocity Y','Angular Velocity Z'};
+    ts.ShowGrid = true;
+    ts.LayoutDimensions = [2 ,1];
+    ts.AxesScaling = 'Auto';
+    ts_parts = clone(ts);
+    ts_parts.LayoutDimensions = [1 ,1];
+    ts_parts.NumInputPorts = 4;
+    ts_parts.ChannelNames = {'W','X','Y','Z'};
+end
 %% Get info
 numSamples = IMU.SamplesPerFrame;
 t = 0:1/fs:(numSamples-1)/fs;
@@ -42,9 +44,11 @@ for k=1:N
         viewer(qimu);
         pause(0);
     end
-%     ts(acc(ii,:), gyro(ii,:));
-    [w,x,y,z] = qimu.parts;
-%     ts_parts(w,x,y,z);
+    if useScope
+        ts(acc(ii,:), gyro(ii,:));
+        [w,x,y,z] = qimu.parts;
+        ts_parts(w,x,y,z);
+    end
 end
 
 %% Cleanup

--- a/sensor_examples/adis16480_motion.m
+++ b/sensor_examples/adis16480_motion.m
@@ -1,0 +1,54 @@
+clear all; %#ok<CLALL>
+
+%% ADIS16480 Motion Example
+
+%% Setup
+% IMU
+IMU = adi.ADIS16480;
+IMU.SamplesPerRead = 8;
+IMU.uri = 'ip:analog';
+IMU.SampleRate = 128;
+IMU.EnabledChannels = 1:6;
+fs = IMU.SampleRate;
+% Filter
+ifilt = imufilter('SampleRate', fs);
+% Scopes
+N = 500;
+viewer = HelperOrientationViewer;
+% ts = dsp.TimeScope;
+% ts.SampleRate = fs;
+% ts.TimeSpanOverrunAction = 'Scroll';
+% ts.TimeSpan = 1/fs*N;
+% ts.NumInputPorts = 2;
+% ts.ShowLegend = true;
+% ts.ChannelNames = {'Acceleration X','Acceleration Y','Acceleration Z',...
+%     'Angular Velocity X','Angular Velocity Y','Angular Velocity Z'};
+% ts.ShowGrid = true;
+% ts.LayoutDimensions = [2 ,1];
+% ts.AxesScaling = 'Auto';
+% ts_parts = clone(ts);
+% ts_parts.LayoutDimensions = [1 ,1];
+% ts_parts.NumInputPorts = 4;
+% ts_parts.ChannelNames = {'W','X','Y','Z'};
+
+%% Get info
+numSamples = IMU.SamplesPerFrame;
+t = 0:1/fs:(numSamples-1)/fs;
+
+for k=1:N
+    [acc,gyro] = IMU();
+    for ii=1:size(acc,1)
+        qimu = ifilt(acc(ii,:), gyro(ii,:));
+        viewer(qimu);
+        pause(0);
+    end
+%     ts(acc(ii,:), gyro(ii,:));
+    [w,x,y,z] = qimu.parts;
+%     ts_parts(w,x,y,z);
+end
+
+%% Cleanup
+release(ifilt);
+release(IMU);
+release(viewer);
+% release(ts);

--- a/sensor_examples/adis16480_motion.m
+++ b/sensor_examples/adis16480_motion.m
@@ -55,4 +55,6 @@ end
 release(ifilt);
 release(IMU);
 release(viewer);
-% release(ts);
+if useScope
+    release(ts);
+end


### PR DESCRIPTION
I added a switch case in stepImpl that would either call stepAccelGyro or stepAccelGyroMag depending on number of EnabledChannels.

setScales was modified to return only the scales for the enabled channels, otherwise matrix dimensions would not agree.

**This PR does not address the issue with data size mismatch in the buffer.**

Added examples based on existing adis16460 scripts.